### PR TITLE
Make it build on Cygwin

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,5 +7,5 @@ test:
 	./spp_test
 
 spp_test: spp_test.cc sparsepp.h makefile
-	$(CXX) -O2 -std=c++0x -D_XOPEN_SOURCE=700 -D_CRT_SECURE_NO_WARNINGS spp_test.cc -o spp_test
+	$(CXX) -O2 -std=c++0x -Wall -pedantic -Wextra -D_XOPEN_SOURCE=700 -D_CRT_SECURE_NO_WARNINGS spp_test.cc -o spp_test
 

--- a/makefile
+++ b/makefile
@@ -7,5 +7,5 @@ test:
 	./spp_test
 
 spp_test: spp_test.cc sparsepp.h makefile
-	$(CXX) -O2 -std=c++0x -D_CRT_SECURE_NO_WARNINGS spp_test.cc -o spp_test
+	$(CXX) -O2 -std=c++0x -D_XOPEN_SOURCE=700 -D_CRT_SECURE_NO_WARNINGS spp_test.cc -o spp_test
 

--- a/sparsepp.h
+++ b/sparsepp.h
@@ -1080,7 +1080,7 @@ inline void hash_combine(std::size_t& seed, T const& v)
     combiner(seed, hasher(v));
 }
     
-};
+}
 
 #endif // spp_utils_h_guard_
 

--- a/spp_test.cc
+++ b/spp_test.cc
@@ -835,7 +835,7 @@ struct TypeList3
   typedef typelist::type1 classname##_type6;    \
   typedef typelist::type1 classname##_type7;   \
   typedef typelist::type1 classname##_type8;   \
-  typedef typelist::type1 classname##_type9; 
+  typedef typelist::type1 classname##_type9
 
 template<typename C1, typename C2, typename C3, typename C4, typename C5,
          typename C6, typename C7, typename C8, typename C9> 
@@ -862,7 +862,7 @@ struct TypeList9
   typedef typelist::type7 classname##_type7;    \
   typedef typelist::type8 classname##_type8;    \
   typedef typelist::type9 classname##_type9;    \
-  static const int classname##_numtypes = 9;
+  static const int classname##_numtypes = 9
 
 #define TYPED_TEST(superclass, testname)                                \
   template<typename TypeParam>                                          \


### PR DESCRIPTION
strdup is not visible on Cygwin unless some POSIX or XOPEN macro is defined.