### PR TITLE
small fix for compiling on clang (Apple LLVM version 8.0.0 (clang-800.0.42.1))

### DIFF
--- a/sparsepp/spp_utils.h
+++ b/sparsepp/spp_utils.h
@@ -84,7 +84,7 @@
        #include <functional>
        #define SPP_HASH_CLASS  std::hash
     #else
-       #include <tr1/unordered_map>
+       #include <tr1/functional>
        #define SPP_HASH_CLASS std::tr1::hash
     #endif
 


### PR DESCRIPTION
I had difficulty compiling this on the aforementioned version of clang (provided by Apple). I simply changed one `include` line to fix this. For reference:

$ clang++ --version
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin