### PR TITLE
Use relative includes within library so it is not necessary to pass -I to the compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ int main()
 
 ## Installation
 
-No compilation is needed, as this is a header-only library. The installation consist in copying the sparsepp directory wherever it will be convenient to include in your project(s). Also make the path to this directory is provided to the compiler with the `-I` option.
+No compilation is needed, as this is a header-only library. The installation consist in copying the sparsepp directory wherever it will be convenient to include in your project(s).
 
 ## Warning - iterator invalidation on erase/insert
 

--- a/sparsepp/spp.h
+++ b/sparsepp/spp.h
@@ -60,12 +60,12 @@
 #include <iosfwd>
 #include <ios>
 
-#include <sparsepp/spp_stdint.h>  // includes spp_config.h
-#include <sparsepp/spp_traits.h>
-#include <sparsepp/spp_utils.h>
+#include "spp_stdint.h"  // includes spp_config.h
+#include "spp_traits.h"
+#include "spp_utils.h"
 
 #ifdef SPP_INCLUDE_SPP_ALLOC
-    #include <sparsepp/spp_dlalloc.h>
+    #include "spp_dlalloc.h"
 #endif
 
 #if !defined(SPP_NO_CXX11_HDR_INITIALIZER_LIST)

--- a/sparsepp/spp_dlalloc.h
+++ b/sparsepp/spp_dlalloc.h
@@ -6,8 +6,8 @@
    see: http://g.oswego.edu/dl/html/malloc.html
 */
 
-#include <sparsepp/spp_utils.h>
-#include <sparsepp/spp_smartptr.h>
+#include "spp_utils.h"
+#include "spp_smartptr.h"
 
 
 #ifndef SPP_FORCEINLINE

--- a/sparsepp/spp_smartptr.h
+++ b/sparsepp/spp_smartptr.h
@@ -8,7 +8,7 @@
  */
 
 #include <cassert>
-#include <sparsepp/spp_config.h>
+#include "spp_config.h"
 
 // ------------------------------------------------------------------------
 class spp_rc

--- a/sparsepp/spp_stdint.h
+++ b/sparsepp/spp_stdint.h
@@ -1,7 +1,7 @@
 #if !defined(spp_stdint_h_guard)
 #define spp_stdint_h_guard
 
-#include <sparsepp/spp_config.h>
+#include "spp_config.h"
 
 #if defined(SPP_HAS_CSTDINT) && (__cplusplus >= 201103)
     #include <cstdint>

--- a/sparsepp/spp_traits.h
+++ b/sparsepp/spp_traits.h
@@ -1,7 +1,7 @@
 #if !defined(spp_traits_h_guard)
 #define spp_traits_h_guard
 
-#include <sparsepp/spp_config.h>
+#include "spp_config.h"
 
 template<int S, int H> class HashObject; // for Google's benchmark, not in spp namespace!
 

--- a/tests/makefile
+++ b/tests/makefile
@@ -9,7 +9,7 @@ ifeq ($(OS),Windows_NT)
     LDFLAGS  = -lpsapi
 endif
 
-def: spp_test 
+def: spp_test spp_relative_include_test
 
 all: $(TARGETS)
 
@@ -21,6 +21,10 @@ test:
 
 spp_test: spp_test.cc $(SPP_DEPS) makefile
 	$(CXX) $(CXXFLAGS) -D_CRT_SECURE_NO_WARNINGS spp_test.cc -o spp_test
+
+# Test that it's possible to use spp with relative includes only - without adding -I to the compiler
+spp_relative_include_test: spp_relative_include_test.cc $(SPP_DEPS) makefile
+	$(CXX) $(filter-out -I%,$(CXXFLAGS)) -D_CRT_SECURE_NO_WARNINGS spp_relative_include_test.cc -o spp_test
 
 %: %.cc $(SPP_DEPS) makefile
 	$(CXX) $(CXXFLAGS) -DNDEBUG $< -o $@ $(LDFLAGS)

--- a/tests/spp_relative_include_test.cc
+++ b/tests/spp_relative_include_test.cc
@@ -1,0 +1,7 @@
+// Test that it's possible to use spp with relative includes only - without adding -I to the compiler
+#include "../sparsepp/spp.h"
+
+int main()
+{
+    spp::sparse_hash_map<unsigned, unsigned> dummy;
+}


### PR DESCRIPTION
This is something I had to do to be able to use this library in my company.

The build system is tricky and does not automatically propagate the -I flag to all components. So if I want to use spp in one header that is used by other components, I have to add -I to the makefile of the users. I also don't want to automatically add that to all components too.
(This btw is an annoying problem we had with boost)

I believe the library becomes more "drop-in" by using relative includes within its files, since no change to the build system is required. I'm not aware of drawbacks either.