### PR TITLE
Allow sparsepp to be targeted to FreeBSD

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -11,6 +11,9 @@ else
     ifeq ($(OS),Linux)
         CXXFLAGS        += -D_XOPEN_SOURCE=700
     endif
+    ifeq ($(OS),FreeBSD)
+	LDFLAGS		= -lkvm
+    endif
 endif
 
 all: $(TARGETS)

--- a/examples/makefile
+++ b/examples/makefile
@@ -1,11 +1,16 @@
 CXXFLAGS     = -O2 -std=c++11 -I..
-CXXFLAGS    += -Wall -pedantic -Wextra -D_XOPEN_SOURCE=700 
+CXXFLAGS    += -Wall -pedantic -Wextra
 SPP_DEPS_1   =  spp.h spp_utils.h spp_dlalloc.h spp_traits.h spp_config.h
 SPP_DEPS     = $(addprefix ../sparsepp/,$(SPP_DEPS_1))
 TARGETS      = emplace hash_std serialize_file serialize_stream serialize_large
 
 ifeq ($(OS),Windows_NT)
     LDFLAGS  = -lpsapi
+else
+    OS = $(shell uname -s)
+    ifeq ($(OS),Linux)
+        CXXFLAGS        += -D_XOPEN_SOURCE=700
+    endif
 endif
 
 all: $(TARGETS)

--- a/sparsepp/spp_memory.h
+++ b/sparsepp/spp_memory.h
@@ -14,9 +14,12 @@
     #include <Psapi.h>
     #undef min
     #undef max
-#else
+#elif defined(__linux__)
     #include <sys/types.h>
     #include <sys/sysinfo.h>
+#elif defined(__FreeBSD__)
+    #include <sys/types.h>
+    #include <sys/sysctl.h>
 #endif
 
 namespace spp
@@ -28,7 +31,7 @@ namespace spp
         memInfo.dwLength = sizeof(MEMORYSTATUSEX);
         GlobalMemoryStatusEx(&memInfo);
         return static_cast<uint64_t>(memInfo.ullTotalPageFile);
-#else
+#elif defined(__linux__)
         struct sysinfo memInfo;
         sysinfo (&memInfo);
         auto totalVirtualMem = memInfo.totalram;
@@ -46,7 +49,7 @@ namespace spp
         memInfo.dwLength = sizeof(MEMORYSTATUSEX);
         GlobalMemoryStatusEx(&memInfo);
         return static_cast<uint64_t>(memInfo.ullTotalPageFile - memInfo.ullAvailPageFile);
-#else
+#elif defined(__linux__)
         struct sysinfo memInfo;
         sysinfo(&memInfo);
         auto virtualMemUsed = memInfo.totalram - memInfo.freeram;
@@ -64,7 +67,7 @@ namespace spp
         PROCESS_MEMORY_COUNTERS_EX pmc;
         GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PPROCESS_MEMORY_COUNTERS>(&pmc), sizeof(pmc));
         return static_cast<uint64_t>(pmc.PrivateUsage);
-#else
+#elif defined(__linux__)
         auto parseLine = 
             [](char* line)->int
             {
@@ -105,7 +108,7 @@ namespace spp
         memInfo.dwLength = sizeof(MEMORYSTATUSEX);
         GlobalMemoryStatusEx(&memInfo);
         return static_cast<uint64_t>(memInfo.ullTotalPhys);
-#else
+#elif defined(__linux__)
         struct sysinfo memInfo;
         sysinfo(&memInfo);
 

--- a/sparsepp/spp_memory.h
+++ b/sparsepp/spp_memory.h
@@ -18,8 +18,12 @@
     #include <sys/types.h>
     #include <sys/sysinfo.h>
 #elif defined(__FreeBSD__)
-    #include <sys/types.h>
+    #include <paths.h>
+    #include <fcntl.h>
+    #include <kvm.h>
+    #include <unistd.h>
     #include <sys/sysctl.h>
+    #include <sys/user.h>
 #endif
 
 namespace spp
@@ -39,6 +43,25 @@ namespace spp
         totalVirtualMem += memInfo.totalswap;
         totalVirtualMem *= memInfo.mem_unit;
         return static_cast<uint64_t>(totalVirtualMem);
+#elif defined(__FreeBSD__)
+        kvm_t *kd;
+        u_int pageCnt;
+        size_t pageCntLen = sizeof(pageCnt);
+        u_int pageSize;
+        struct kvm_swap kswap;
+        uint64_t totalVirtualMem;
+
+        pageSize = static_cast<u_int>(getpagesize());
+
+        sysctlbyname("vm.stats.vm.v_page_count", &pageCnt, &pageCntLen, NULL, 0);
+        totalVirtualMem = pageCnt * pageSize;
+
+        kd = kvm_open(NULL, _PATH_DEVNULL, NULL, O_RDONLY, "kvm_open");
+        kvm_getswapinfo(kd, &kswap, 1, 0);
+        kvm_close(kd);
+        totalVirtualMem += kswap.ksw_total * pageSize;
+
+        return totalVirtualMem;
 #endif
     }
 
@@ -58,6 +81,27 @@ namespace spp
         virtualMemUsed *= memInfo.mem_unit;
 
         return static_cast<uint64_t>(virtualMemUsed);
+#elif defined(__FreeBSD__)
+        kvm_t *kd;
+        u_int pageSize;
+        u_int pageCnt, freeCnt;
+        size_t pageCntLen = sizeof(pageCnt);
+        size_t freeCntLen = sizeof(freeCnt);
+        struct kvm_swap kswap;
+        uint64_t virtualMemUsed;
+
+        pageSize = static_cast<u_int>(getpagesize());
+
+        sysctlbyname("vm.stats.vm.v_page_count", &pageCnt, &pageCntLen, NULL, 0);
+        sysctlbyname("vm.stats.vm.v_free_count", &freeCnt, &freeCntLen, NULL, 0);
+        virtualMemUsed = (pageCnt - freeCnt) * pageSize;
+
+        kd = kvm_open(NULL, _PATH_DEVNULL, NULL, O_RDONLY, "kvm_open");
+        kvm_getswapinfo(kd, &kswap, 1, 0);
+        kvm_close(kd);
+        virtualMemUsed += kswap.ksw_used * pageSize;
+
+        return virtualMemUsed;
 #endif
     }
 
@@ -98,6 +142,13 @@ namespace spp
 
         fclose(file);
         return static_cast<uint64_t>(result) * 1024;
+#elif defined(__FreeBSD__)
+        struct kinfo_proc info;
+        size_t infoLen = sizeof(info);
+        int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
+
+        sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &infoLen, NULL, 0);
+        return static_cast<uint64_t>(info.ki_rssize * getpagesize());
 #endif
     }
 
@@ -116,6 +167,13 @@ namespace spp
 
         totalPhysMem *= memInfo.mem_unit;
         return static_cast<uint64_t>(totalPhysMem);
+#elif defined(__FreeBSD__)
+        u_long physMem;
+        size_t physMemLen = sizeof(physMem);
+        int mib[] = { CTL_HW, HW_PHYSMEM };
+
+        sysctl(mib, sizeof(mib) / sizeof(*mib), &physMem, &physMemLen, NULL, 0);
+        return physMem;
 #endif
     }
 

--- a/tests/makefile
+++ b/tests/makefile
@@ -12,6 +12,9 @@ else
     ifeq ($(OS),Linux)
         CXXFLAGS        += -D_XOPEN_SOURCE=700
     endif
+    ifeq ($(OS),FreeBSD)
+	LDFLAGS		= -lkvm
+    endif
 endif
 
 def: spp_test spp_relative_include_test

--- a/tests/makefile
+++ b/tests/makefile
@@ -1,5 +1,5 @@
 CXXFLAGS     = -O2 -std=c++11 -I..
-CXXFLAGS    += -Wall -pedantic -Wextra -D_XOPEN_SOURCE=700 
+CXXFLAGS    += -Wall -pedantic -Wextra
 SPP_DEPS_1   =  spp.h spp_utils.h spp_dlalloc.h spp_traits.h spp_config.h
 SPP_DEPS     = $(addprefix ../sparsepp/,$(SPP_DEPS_1))
 TARGETS      = spp_test spp_alloc_test spp_bitset_test perftest1 bench
@@ -7,6 +7,11 @@ TARGETS      = spp_test spp_alloc_test spp_bitset_test perftest1 bench
 
 ifeq ($(OS),Windows_NT)
     LDFLAGS  = -lpsapi
+else
+    OS = $(shell uname -s)
+    ifeq ($(OS),Linux)
+        CXXFLAGS        += -D_XOPEN_SOURCE=700
+    endif
 endif
 
 def: spp_test spp_relative_include_test


### PR DESCRIPTION
Currently, due to the heavy use of Linux-specific APIs in non-Windows section of sparsepp/spp_memory.h , the library cannot be built in FreeBSD or possibly other platforms.

With this pull request, FreeBSD-related support is added to sparsepp/spp_memory.h to allow spp_memory.h to be built in FreeBSD, with the hope that someone interested may further add OpenBSD support based on the changes.