### PR TITLE
Don't overwrite test binary

### DIFF
--- a/tests/makefile
+++ b/tests/makefile
@@ -32,7 +32,7 @@ spp_test: spp_test.cc $(SPP_DEPS) makefile
 
 # Test that it's possible to use spp with relative includes only - without adding -I to the compiler
 spp_relative_include_test: spp_relative_include_test.cc $(SPP_DEPS) makefile
-	$(CXX) $(filter-out -I%,$(CXXFLAGS)) -D_CRT_SECURE_NO_WARNINGS spp_relative_include_test.cc -o spp_test
+	$(CXX) $(filter-out -I%,$(CXXFLAGS)) -D_CRT_SECURE_NO_WARNINGS spp_relative_include_test.cc -o spp_relative_include_test
 
 %: %.cc $(SPP_DEPS) makefile
 	$(CXX) $(CXXFLAGS) -DNDEBUG $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
Noticed when running "make", the test binary comes out empty. That's because the other test rule (which I inserted :( ) was overwriting the binary.