### PR TITLE
Consider pointer types relocatable

### DIFF
--- a/sparsepp/spp_traits.h
+++ b/sparsepp/spp_traits.h
@@ -90,7 +90,10 @@ template<typename T> struct is_reference<T&> : true_type {};
 // ------------------------------------------------------------------------
 template <class T> struct is_relocatable;
 template <class T> struct is_relocatable :
-     integral_constant<bool, (is_integral<T>::value || is_floating_point<T>::value)>
+     integral_constant<bool, (is_integral<T>::value ||
+                              is_floating_point<T>::value ||
+                              is_pointer<T>::value
+                             )>
 { };
 
 template<int S, int H> struct is_relocatable<HashObject<S, H> > : true_type { };

--- a/tests/makefile
+++ b/tests/makefile
@@ -32,7 +32,7 @@ spp_test: spp_test.cc $(SPP_DEPS) makefile
 
 # Test that it's possible to use spp with relative includes only - without adding -I to the compiler
 spp_relative_include_test: spp_relative_include_test.cc $(SPP_DEPS) makefile
-	$(CXX) $(filter-out -I%,$(CXXFLAGS)) -D_CRT_SECURE_NO_WARNINGS spp_relative_include_test.cc -o spp_test
+	$(CXX) $(filter-out -I%,$(CXXFLAGS)) -D_CRT_SECURE_NO_WARNINGS spp_relative_include_test.cc -o spp_relative_include_test
 
 %: %.cc $(SPP_DEPS) makefile
 	$(CXX) $(CXXFLAGS) -DNDEBUG $< -o $@ $(LDFLAGS)


### PR DESCRIPTION
I guess it's pretty common to use pointers as keys and values. At least I use it in more than one case. Consider them as relocatable.